### PR TITLE
FOXエンゲージメント view_topでFOX成果地点IDを送らないようにした

### DIFF
--- a/lang/ja/doc/fox_engagement/ViewToppageEvent.md
+++ b/lang/ja/doc/fox_engagement/ViewToppageEvent.md
@@ -7,8 +7,7 @@
 JSONObject eventInfo = new JSONObject("{" +
                                  "'din':'2016-01-02'," +
                                  "'dout':'2016-01-05'," +
-                                 "'criteo_partner_id':'XXXXX'," +
-                                 "'fox_cvpoint': '12345'" +
+                                 "'criteo_partner_id':'XXXXX'" +
                                  "}");
 AnalyticsManager.sendEvent(this, "_view_toppage", null, null, 0, eventInfo);
 ```
@@ -31,8 +30,6 @@ AnalyticsManager.sendEvent(this, "_view_toppage", null, null, 0, eventInfo);
 |:----------|:-----------:|:------------|
 |eventInfo (din/dout)|JSONObject|日付の指定がある場合は入力（任意）|
 |eventInfo (criteo_partner_id)|JSONObject|CriteoアカウントIDが同一アプリで異なる場合は入力(任意)|
-|eventInfo (fox_cvpoint)|JSONObject|F.O.Xの成果地点IDを設定します。(任意)|
-
 
 ---
 [戻る](/lang/ja//doc/fox_engagement/README.md)


### PR DESCRIPTION
LTVにview_topのデータを送ると負荷が上がりリトライが発生するため。

@czendo 共有済み。